### PR TITLE
Update shell configs and k8s tooling

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -22,6 +22,10 @@ fi
 if [ -d "$HOME/Applications" ] && [ "${PATH#*"$HOME"/Applications}" == "$PATH" ]; then
     export PATH="$HOME/Applications:$PATH"
 fi
+# adding ~/.npm-global folder to the PATH (appimage default application folder)
+if [ -d "$HOME/.npm-global/bin" ] && [ "${PATH#*"$HOME"/.npm-global/bin}" == "$PATH" ]; then
+    export PATH="$HOME/.npm-global/bin:$PATH"
+fi
 # -----------------------------------------------------------------------------
 
 # --------------------------- History configuration ---------------------------

--- a/bin/.local/bin/scripts/k8s-setup.sh
+++ b/bin/.local/bin/scripts/k8s-setup.sh
@@ -53,7 +53,7 @@ HELM_REPOS=(
   "metallb              https://metallb.github.io/metallb"
   "metrics-server       https://kubernetes-sigs.github.io/metrics-server/"
   "minio                https://operator.min.io/"
-  "openebs              https://openebs.github.io/charts"
+  "openebs              https://openebs.github.io/openebs"
   "open-telemetry       https://open-telemetry.github.io/opentelemetry-helm-charts"
   "podinfo              https://stefanprodan.github.io/podinfo"
   "prometheus-community https://prometheus-community.github.io/helm-charts"
@@ -105,25 +105,26 @@ helm repo update
 
 
 # Installing hcl2json
-if [ "$(command -v hcl2json)" ]; then
-  echo "hcl2json already installed"
-else
-  DOWNLOAD_URL_HCL2JSON=$(curl -s https://api.github.com/repos/tmccombs/hcl2json/releases/latest \
-    | jq -r --arg name "hcl2json_linux_amd64" '.assets[] | select(.name == $name) | .browser_download_url')
-  curl -fsSL "$DOWNLOAD_URL_HCL2JSON" -o "$BIN_DIR/hcl2json"
-  chmod +x "$BIN_DIR"/hcl2json
-  ln -sf "$BIN_DIR"/hcl2json "$HOME"/.local/bin/hcl2json
-  echo "hcl2json instalado em $HOME/.local/bin/"
-fi
+# if [ "$(command -v hcl2json)" ]; then
+#   echo "hcl2json already installed"
+# else
+#   DOWNLOAD_URL_HCL2JSON=$(curl -s https://api.github.com/repos/tmccombs/hcl2json/releases/latest \
+#     | jq -r --arg name "hcl2json_linux_amd64" '.assets[] | select(.name == $name) | .browser_download_url')
+#   curl -fsSL "$DOWNLOAD_URL_HCL2JSON" -o "$BIN_DIR/hcl2json"
+#   chmod +x "$BIN_DIR"/hcl2json
+#   ln -sf "$BIN_DIR"/hcl2json "$HOME"/.local/bin/hcl2json
+#   echo "hcl2json instalado em $HOME/.local/bin/"
+# fi
 
 # Installing kubescape
-if [ "$(command -v kubescape)" ]; then
-  echo "kubescape already installed"
-else
-  DOWNLOAD_URL_KUBESCAPE=$(curl -s https://api.github.com/repos/kubescape/kubescape/releases/latest \
-    | jq -r --arg name "kubescape-ubuntu-latest" '.assets[] | select(.name == $name) | .browser_download_url')
-  curl -fsSL "$DOWNLOAD_URL_KUBESCAPE" -o "$BIN_DIR/kubescape"
-  chmod +x "$BIN_DIR"/kubescape
-  ln -sf "$BIN_DIR"/kubescape "$HOME"/.local/bin/kubescape
-  echo "kubescape instalado em $HOME/.local/bin/"
-fi
+# if [ "$(command -v kubescape)" ]; then
+#   echo "kubescape already installed"
+# else
+#   DOWNLOAD_URL_KUBESCAPE=$(curl -s https://api.github.com/repos/kubescape/kubescape/releases/latest \
+#     | jq -r --arg name "kubescape-ubuntu-latest" '.assets[] | select(.name == $name) | .browser_download_url')
+#   curl -fsSL "$DOWNLOAD_URL_KUBESCAPE" -o "$BIN_DIR/kubescape"
+#   chmod +x "$BIN_DIR"/kubescape
+#   ln -sf "$BIN_DIR"/kubescape "$HOME"/.local/bin/kubescape
+#   echo "kubescape instalado em $HOME/.local/bin/"
+# fi
+#

--- a/dolphin/.local/share/kxmlgui5/dolphin/dolphinui.rc
+++ b/dolphin/.local/share/kxmlgui5/dolphin/dolphinui.rc
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <!DOCTYPE gui SYSTEM 'kpartgui.dtd'>
-<gui name="dolphin" version="43">
+<gui name="dolphin" version="46">
  <MenuBar>
   <Menu name="file">
    <Action name="new_menu"/>
@@ -73,6 +73,7 @@
    <Action name="open_preferred_search_tool"/>
    <Action name="open_terminal"/>
    <Action name="open_terminal_here"/>
+   <Action name="manage_disk_space"/>
    <Action name="compare_files"/>
    <Action name="change_remote_encoding"/>
   </Menu>
@@ -124,7 +125,7 @@
   </disable>
  </State>
  <ActionProperties scheme="Default">
-  <Action name="view_mode" priority="0"/>
+  <Action name="view_settings" priority="0"/>
   <Action name="compact" priority="0"/>
   <Action name="details" priority="0"/>
   <Action name="edit_copy" priority="0"/>
@@ -138,6 +139,7 @@
   <Action name="stop" priority="0"/>
   <Action name="toggle_filter" priority="0"/>
   <Action name="toggle_search" priority="0"/>
+  <Action name="view_mode" priority="0"/>
   <Action name="view_zoom_in" priority="0"/>
   <Action name="view_zoom_out" priority="0"/>
   <Action name="view_zoom_reset" priority="0"/>

--- a/kanata/.config/kanata/kanata.kbd
+++ b/kanata/.config/kanata/kanata.kbd
@@ -1,0 +1,27 @@
+;; defsrc is still necessary
+(defcfg
+  process-unmapped-keys yes
+)
+
+(defsrc
+  a s d f j k l ;
+)
+(defvar
+  tap-time 150
+  hold-time 200
+)
+
+(defalias
+  a (multi f24 (tap-hold $tap-time $hold-time a lmet))
+  s (multi f24 (tap-hold $tap-time $hold-time s lalt))
+  d (multi f24 (tap-hold $tap-time $hold-time d lsft))
+  f (multi f24 (tap-hold $tap-time $hold-time f lctl))
+  j (multi f24 (tap-hold $tap-time $hold-time j rctl))
+  k (multi f24 (tap-hold $tap-time $hold-time k rsft))
+  l (multi f24 (tap-hold $tap-time $hold-time l ralt))
+  ; (multi f24 (tap-hold $tap-time $hold-time ; rmet))
+)
+
+(deflayer base
+  @a @s @d @f @j @k @l @;
+)

--- a/stow.sh
+++ b/stow.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # ----------------------------
-# Color definitions
+# Color definitions for output formatting
 # ----------------------------
 RED="\033[0;31m"
 GREEN="\033[0;32m"
@@ -11,7 +11,7 @@ BLUE="\033[1;34m"
 RESET="\033[0m"
 
 # ----------------------------
-# Helper: print usage
+# Helper function: print usage instructions
 # ----------------------------
 usage() {
   echo -e "${BLUE}Usage:${RESET}"
@@ -33,7 +33,7 @@ usage() {
 }
 
 # ----------------------------
-# Check dependencies
+# Check if 'stow' is installed
 # ----------------------------
 if ! command -v stow >/dev/null 2>&1; then
   echo -e "${RED}Error: 'stow' is not installed or not in PATH.${RESET}" >&2
@@ -41,48 +41,48 @@ if ! command -v stow >/dev/null 2>&1; then
 fi
 
 # ----------------------------
-# Initialization
+# Initialization of variables
 # ----------------------------
-DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET_DIR="$HOME"
-ACTION="--stow"
-DRY_RUN=false
-VERBOSE=false
-STOW_DIRS=()
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # Directory containing this script
+TARGET_DIR="$HOME"      # Where dotfiles will be stowed (usually $HOME)
+ACTION="--stow"         # Default action is to stow (link files)
+DRY_RUN=false           # If true, only simulate actions
+VERBOSE=false           # If true, show verbose output
+STOW_DIRS=()            # List of packages to stow
 
 # ----------------------------
-# Argument parsing
+# Parse command-line arguments
 # ----------------------------
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --uninstall)
-      ACTION="--delete"
+      ACTION="--delete" # Change action to delete (unstow)
       shift
       ;;
     --dry-run)
-      DRY_RUN=true
+      DRY_RUN=true      # Enable dry-run mode
       shift
       ;;
     --verbose)
-      VERBOSE=true
+      VERBOSE=true      # Enable verbose output
       shift
       ;;
     --help)
-      usage
+      usage             # Show usage and exit
       ;;
     -*)
       echo -e "${RED}Unknown option: $1${RESET}" >&2
       usage
       ;;
     *)
-      STOW_DIRS+=("$1")
+      STOW_DIRS+=("$1") # Add package to list
       shift
       ;;
   esac
 done
 
 # ----------------------------
-# Discover packages (if none specified)
+# If no packages specified, stow all directories in DOTFILES_DIR
 # ----------------------------
 if [[ ${#STOW_DIRS[@]} -eq 0 ]]; then
   for d in "$DOTFILES_DIR"/*/; do
@@ -91,7 +91,7 @@ if [[ ${#STOW_DIRS[@]} -eq 0 ]]; then
 fi
 
 # ----------------------------
-# Validate directories
+# Validate that each package directory exists
 # ----------------------------
 for dir in "${STOW_DIRS[@]}"; do
   if [[ ! -d "$DOTFILES_DIR/$dir" ]]; then
@@ -101,7 +101,7 @@ for dir in "${STOW_DIRS[@]}"; do
 done
 
 # ----------------------------
-# Summary
+# Print summary of actions to be performed
 # ----------------------------
 echo -e "${BLUE}Dotfiles directory:${RESET} $DOTFILES_DIR"
 echo -e "${BLUE}Target directory:  ${RESET} $TARGET_DIR"
@@ -112,7 +112,7 @@ echo -e "${BLUE}Packages:          ${RESET} ${STOW_DIRS[*]}"
 echo
 
 # ----------------------------
-# Apply or simulate
+# Apply stow/uninstall for each package
 # ----------------------------
 for dir in "${STOW_DIRS[@]}"; do
   echo -e "${GREEN}Processing: $dir${RESET}"
@@ -121,8 +121,10 @@ for dir in "${STOW_DIRS[@]}"; do
   CMD+=("$dir")
 
   if $DRY_RUN; then
+    # Show what would be run, but do not execute
     echo -e "${YELLOW}Would run:${RESET} ${CMD[*]}"
   else
+    # Run the stow command and handle errors/output
     if ! OUTPUT="$("${CMD[@]}" 2>&1)"; then
       echo -e "${RED}Error processing package: $dir${RESET}"
       echo "$OUTPUT"
@@ -133,4 +135,3 @@ for dir in "${STOW_DIRS[@]}"; do
 done
 
 echo -e "\n${GREEN}Done.${RESET}"
-

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -13,6 +13,7 @@ path=(
     ${KREW_ROOT:-$HOME/.krew}/bin   # Krew PATH (plugin manager for kubectl)
     $HOME/Applications              # AppImage default folder
     $HOME/sync/git/chess/kotr/bin/  # kotr script
+    $HOME/.npm-global/bin           # npm packages
 )
 typeset -U path                     # Remove duplicate directories
 path=($^path(N-/))                  # Remove non-existent directories
@@ -204,6 +205,7 @@ compdef kubecolor=kubectl
 [ -f ~/.shell_functions ] && . ~/.shell_functions
 [ -f ~/.shell_aliases_private ] && . ~/.shell_aliases_private
 [ -f ~/.shell_functions_private ] && . ~/.shell_functions_private
+[ -f ~/.kubectl-getinfo ] && . ~/.kubectl-getinfo
 # -----------------------------------------------------------------------------
 
 # --------------------------------- Autokube ----------------------------------


### PR DESCRIPTION
## Summary
- Add npm-global bin directory to PATH in bash and zsh configurations
- Add kanata keyboard remapper configuration
- Update k8s-setup.sh with OpenEBS helm repo fix and disable unused tool installations
- Improve stow.sh with inline documentation

## Changes
- `bash/.bashrc` - Add ~/.npm-global/bin to PATH
- `zsh/.zshrc` - Add npm-global PATH and source kubectl-getinfo
- `kanata/.config/kanata/kanata.kbd` - New kanata keyboard config
- `bin/.local/bin/scripts/k8s-setup.sh` - Update OpenEBS repo, comment out hcl2json/kubescape
- `stow.sh` - Add inline comments for clarity
- `dolphin/.local/share/kxmlgui5/dolphin/dolphinui.rc` - Update Dolphin UI config